### PR TITLE
Add a MaxVariables limits

### DIFF
--- a/engine/builtin_test.go
+++ b/engine/builtin_test.go
@@ -952,7 +952,7 @@ func TestTermVariables(t *testing.T) {
 func TestOp(t *testing.T) {
 	t.Run("insert", func(t *testing.T) {
 		t.Run("atom", func(t *testing.T) {
-			varCounter = 1
+			varCounter.count = 1
 
 			vm := VM{_operators: newOperators()}
 			vm.getOperators().define(900, operatorSpecifierXFX, NewAtom(`+++`))

--- a/engine/text_test.go
+++ b/engine/text_test.go
@@ -24,7 +24,7 @@ func mustOpen(fs fs.FS, name string) fs.File {
 }
 
 func TestVM_Compile(t *testing.T) {
-	varCounter = 1
+	varCounter.count = 1
 
 	tests := []struct {
 		title  string
@@ -483,7 +483,7 @@ bar(b).
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
 			var vm VM
-			varCounter = 1 // Global var cause issues in testing environment that call in randomly order for checking equality between procedure clause args
+			varCounter.count = 1 // Global var cause issues in testing environment that call in randomly order for checking equality between procedure clause args
 
 			vm.getOperators().define(1200, operatorSpecifierXFX, atomIf)
 			vm.getOperators().define(1200, operatorSpecifierXFX, atomArrow)

--- a/engine/variable_test.go
+++ b/engine/variable_test.go
@@ -141,3 +141,39 @@ func Test_freeVariablesSet(t *testing.T) {
 		assert.Equal(t, tt.fv, newFreeVariablesSet(tt.t, tt.v, nil))
 	}
 }
+
+func Test_maxVariables(t *testing.T) {
+	tests := []struct {
+		title         string
+		init          func()
+		max           uint64
+		expectedCount uint64
+		shouldPanic   bool
+	}{
+		{title: "no limits", init: func() {
+			NewVariable()
+			NewVariable()
+		}, max: 0, expectedCount: 2},
+		{title: "limit", init: func() {
+			NewVariable()
+			NewVariable()
+		}, max: 2, expectedCount: 2},
+		{title: "limit reached", init: func() {
+			NewVariable()
+			NewVariable()
+		}, max: 1, expectedCount: 1, shouldPanic: true},
+	}
+
+	for _, tt := range tests {
+		varCounter.count = 0 // reset at each test
+
+		maxVariables = tt.max
+
+		if tt.shouldPanic {
+			assert.Panics(t, tt.init)
+		} else {
+			tt.init()
+		}
+		assert.Equal(t, varCounter.count, tt.expectedCount)
+	}
+}

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -280,6 +280,7 @@ func (vm *VM) SetUserOutput(s *Stream) {
 }
 
 // SetMaxVariables sets the maximum number of variables that the VM can create.
+// Zero value mean no limits
 func (vm *VM) SetMaxVariables(n uint64) {
 	vm.maxVariables = n
 	maxVariables = n

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -278,7 +278,7 @@ func (vm *VM) SetUserOutput(s *Stream) {
 
 // ResetEnv is used to reset all global variable
 func (vm *VM) ResetEnv() {
-	varCounter = 0
+	varCounter.count = 0
 	varContext = NewVariable()
 	rootContext = NewAtom("root")
 	rootEnv = &Env{

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -70,6 +70,9 @@ type VM struct {
 	streams       streams
 	input, output *Stream
 
+	// Limits
+	maxVariables uint64
+
 	// Misc
 	debug bool
 }
@@ -276,6 +279,12 @@ func (vm *VM) SetUserOutput(s *Stream) {
 	vm.output = s
 }
 
+// SetMaxVariables sets the maximum number of variables that the VM can create.
+func (vm *VM) SetMaxVariables(n uint64) {
+	vm.maxVariables = n
+	maxVariables = n
+}
+
 // ResetEnv is used to reset all global variable
 func (vm *VM) ResetEnv() {
 	varCounter.count = 0
@@ -287,6 +296,7 @@ func (vm *VM) ResetEnv() {
 			value: rootContext,
 		},
 	}
+	maxVariables = vm.maxVariables
 }
 
 func (vm *VM) getProcedure(p procedureIndicator) (procedure, bool) {

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -289,7 +289,7 @@ func TestProcedureIndicator_Apply(t *testing.T) {
 
 func TestVM_ResetEnv(t *testing.T) {
 	var vm VM
-	varCounter = 10
+	varCounter.count = 10
 	varContext = NewVariable()
 	rootContext = NewAtom("non-root")
 	rootEnv = &Env{
@@ -302,7 +302,7 @@ func TestVM_ResetEnv(t *testing.T) {
 	t.Run("Reset environment", func(t *testing.T) {
 		vm.ResetEnv()
 
-		assert.Equal(t, int64(1), varCounter) // 1 because NewVariable() is called in ResetEnv()
+		assert.Equal(t, uint64(1), varCounter.count) // 1 because NewVariable() is called in ResetEnv()
 		assert.Equal(t, "root", rootContext.String())
 		assert.Equal(t, newEnvKey(varContext), rootEnv.binding.key)
 		assert.Equal(t, NewAtom("root"), rootEnv.binding.value)

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -289,6 +289,8 @@ func TestProcedureIndicator_Apply(t *testing.T) {
 
 func TestVM_ResetEnv(t *testing.T) {
 	var vm VM
+	vm.maxVariables = 10
+
 	varCounter.count = 10
 	varContext = NewVariable()
 	rootContext = NewAtom("non-root")
@@ -298,6 +300,7 @@ func TestVM_ResetEnv(t *testing.T) {
 			value: NewAtom("non-root"),
 		},
 	}
+	maxVariables = 20
 
 	t.Run("Reset environment", func(t *testing.T) {
 		vm.ResetEnv()
@@ -306,5 +309,6 @@ func TestVM_ResetEnv(t *testing.T) {
 		assert.Equal(t, "root", rootContext.String())
 		assert.Equal(t, newEnvKey(varContext), rootEnv.binding.key)
 		assert.Equal(t, NewAtom("root"), rootEnv.binding.value)
+		assert.Equal(t, uint64(10), maxVariables)
 	})
 }

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -271,11 +271,18 @@ func TestVM_SetUserOutput(t *testing.T) {
 }
 
 func TestVM_SetMaxVariables(t *testing.T) {
-	t.Run("ok", func(t *testing.T) {
+	t.Run("limits", func(t *testing.T) {
 		var vm VM
 		vm.SetMaxVariables(10)
 		assert.Equal(t, uint64(10), maxVariables)
 		assert.Equal(t, uint64(10), vm.maxVariables)
+	})
+
+	t.Run("no limit", func(t *testing.T) {
+		var vm VM
+		vm.SetMaxVariables(0)
+		assert.Equal(t, uint64(0), maxVariables)
+		assert.Equal(t, uint64(0), vm.maxVariables)
 	})
 }
 

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -270,6 +270,15 @@ func TestVM_SetUserOutput(t *testing.T) {
 	})
 }
 
+func TestVM_SetMaxVariables(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var vm VM
+		vm.SetMaxVariables(10)
+		assert.Equal(t, uint64(10), maxVariables)
+		assert.Equal(t, uint64(10), vm.maxVariables)
+	})
+}
+
 func TestProcedureIndicator_Apply(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		c, err := procedureIndicator{name: NewAtom("foo"), arity: 2}.Apply(NewAtom("a"), NewAtom("b"))
@@ -289,7 +298,7 @@ func TestProcedureIndicator_Apply(t *testing.T) {
 
 func TestVM_ResetEnv(t *testing.T) {
 	var vm VM
-	vm.maxVariables = 10
+	vm.SetMaxVariables(20)
 
 	varCounter.count = 10
 	varContext = NewVariable()
@@ -300,7 +309,7 @@ func TestVM_ResetEnv(t *testing.T) {
 			value: NewAtom("non-root"),
 		},
 	}
-	maxVariables = 20
+	maxVariables = 30
 
 	t.Run("Reset environment", func(t *testing.T) {
 		vm.ResetEnv()
@@ -309,6 +318,6 @@ func TestVM_ResetEnv(t *testing.T) {
 		assert.Equal(t, "root", rootContext.String())
 		assert.Equal(t, newEnvKey(varContext), rootEnv.binding.key)
 		assert.Equal(t, NewAtom("root"), rootEnv.binding.value)
-		assert.Equal(t, uint64(10), maxVariables)
+		assert.Equal(t, uint64(20), maxVariables)
 	})
 }


### PR DESCRIPTION
### 📝 Description

This PR introduces a new global variable to define the maximum number of variables that can be created in the interpreter. This is used to prevent memory overflow or latency issues in predicates that loop on `NewVariable()` calls.

Due to the current design of `NewVariable()`, which uses a global variable counter, I also had to use a global variable to handle the `maxVariables` limit. To avoid changing the signature of `NewVariable()`, which is used extensively throughout the interpreter, the only feasible way to throw an error when the limit is reached is to trigger a panic. This panic is caught by the interpreter and returns a Prolog error without stopping the interpreter.

By default, no limit is set (0 means no limit).

If you have any idea to do in a better way 😇

Used to fix : https://github.com/axone-protocol/axoned/issues/618