### PR TITLE
✨ add lazy sequence support for delayed promises

### DIFF
--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"io"
 	"io/fs"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 // Repeat repeats the continuation until it succeeds.
@@ -1268,7 +1269,7 @@ func Open(vm *VM, sourceSink, mode, stream, options Term, k Cont, env *Env) *Pro
 	case err == nil:
 		if s.mode == ioModeRead {
 			s.source = f
-			s.initRead()
+			_ = s.initRead()
 		} else {
 			s.sink = f
 		}
@@ -2426,9 +2427,7 @@ func StreamProperty(vm *VM, stream, property Term, k Cont, env *Env) *Promise {
 	streams := make([]*Stream, 0, len(vm.streams.elems))
 	switch s := env.Resolve(stream).(type) {
 	case Variable:
-		for _, v := range vm.streams.elems {
-			streams = append(streams, v)
-		}
+		streams = append(streams, vm.streams.elems...)
 	case *Stream:
 		streams = append(streams, s)
 	default:

--- a/engine/lexer.go
+++ b/engine/lexer.go
@@ -737,7 +737,6 @@ func (l *Lexer) fraction() (Token, error) {
 				return Token{}, err
 			case isDecimalDigitChar(r):
 				l.backup()
-				break
 			default:
 				l.backup()
 				if sign != 0 {

--- a/engine/parser.go
+++ b/engine/parser.go
@@ -3,13 +3,14 @@ package engine
 import (
 	"errors"
 	"fmt"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"io"
 	"math/big"
 	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 var (
@@ -530,7 +531,6 @@ func (p *Parser) term0(maxPriority Integer) (Term, error) {
 			return CodeList(unDoubleQuote(t.val)), nil
 		default:
 			p.backup()
-			break
 		}
 	default:
 		p.backup()

--- a/engine/term.go
+++ b/engine/term.go
@@ -2,9 +2,10 @@ package engine
 
 import (
 	"fmt"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"io"
 	"strings"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 // Term is a prolog term.
@@ -23,7 +24,6 @@ type WriteOptions struct {
 	_ops        *operators
 	priority    Integer
 	visited     map[termID]struct{}
-	prefixMinus bool
 	left, right operator
 	maxDepth    Integer
 }

--- a/engine/text.go
+++ b/engine/text.go
@@ -3,9 +3,10 @@ package engine
 import (
 	"context"
 	"fmt"
-	orderedmap "github.com/wk8/go-ordered-map/v2"
 	"io/fs"
 	"strings"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 )
 
 // discontiguousError is an error that the user-defined predicate is defined by clauses which are not consecutive read-terms.
@@ -110,7 +111,7 @@ func (vm *VM) compile(ctx context.Context, text *text, s string, args ...interfa
 			}
 			continue
 		case procedureIndicator{name: atomIf, arity: 2}: // Rule
-			pi, arg, err = piArg(arg(0), nil)
+			pi, _, err = piArg(arg(0), nil)
 			if err != nil {
 				return err
 			}

--- a/interpreter.go
+++ b/interpreter.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	_ "embed" // for go:embed
 	"errors"
-	"github.com/ichiban/prolog/engine"
 	"io"
 	"io/fs"
 	"os"
 	"strings"
+
+	"github.com/ichiban/prolog/engine"
 )
 
 //go:embed bootstrap.pl
@@ -17,7 +18,6 @@ var bootstrap string
 // Interpreter is a Prolog interpreter.
 type Interpreter struct {
 	engine.VM
-	loaded map[string]struct{}
 }
 
 // NewEmpty creates a new Prolog interpreter without any predicates/operators defined.


### PR DESCRIPTION
## Purpose

Introduces the `DelaySeq` function to enhance the management of sequential execution of promise functions through a lazy, pull-based technique.

## Rationale

Currently, the `Delay` function executes promise functions by iterating over a variadic slice. While this approach works well for a small number of promises, it can cause performance degradation and increased memory consumption when handling larger sequences. This issue might arise for instance when implementing native predicates that traverse solution spaces in databases -and more specifically, in the case of axone, when we query the state of the blockchain-, potentially generating a vast number of alternatives.

## Implementation details

The `DelaySeq` function is implemented using a very and minimal pull mechanism based on a single function. This design enables clients to create an on-demand promise generator in a straightforward and efficient way. The impact of the change is also very slight and limited to the `engine/promise` file.

**why Not Use Go 1.23 iterators?**

[Go 1.23 iterators](https://www.dolthub.com/blog/2024-07-12-golang-range-iters-demystified/) operate on a _push_ model, which inverts the control flow compared to the _pull-based_ strategy used here. Although Go provides a mechanism to convert _push-style_ iterators into _pull-style_ ones, this comes with several implications. First, it creates a goroutine under the hood, and second, a cleanup mechanism must absolutely be called to prevent resource leaks. This makes it quite tricky to use in implementing promises in this context.