### PR TITLE
refactor(mod)!: rename the go module of this repository

### DIFF
--- a/cmd/1pl/interpreter.go
+++ b/cmd/1pl/interpreter.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 	"io"
 )
 

--- a/cmd/1pl/main.go
+++ b/cmd/1pl/main.go
@@ -16,8 +16,8 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 const (

--- a/examples/call_go_from_prolog/main.go
+++ b/examples/call_go_from_prolog/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 func main() {

--- a/examples/dcg/main.go
+++ b/examples/dcg/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/ichiban/prolog"
+	"github.com/axone-protocol/prolog"
 )
 
 // This example explains how to parse a simple English sentence with DCG (Definite Clause Grammar).

--- a/examples/embed_prolog_into_go/main.go
+++ b/examples/embed_prolog_into_go/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ichiban/prolog"
+	"github.com/axone-protocol/prolog"
 )
 
 // http://www.cse.unsw.edu.au/~billw/dictionaries/prolog/cut.html

--- a/examples/hanoi/main.go
+++ b/examples/hanoi/main.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/ichiban/prolog"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 func main() {

--- a/examples/initialization/main.go
+++ b/examples/initialization/main.go
@@ -4,7 +4,7 @@ import (
 	_ "embed"
 	"os"
 
-	"github.com/ichiban/prolog"
+	"github.com/axone-protocol/prolog"
 )
 
 //go:embed hello.pl

--- a/examples/sandboxing/main.go
+++ b/examples/sandboxing/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
-	"github.com/ichiban/prolog"
+	"github.com/axone-protocol/prolog"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ichiban/prolog
+module github.com/axone-protocol/prolog
 
 go 1.19
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 //go:embed bootstrap.pl

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/solutions.go
+++ b/solutions.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 )
 
 // ErrClosed indicates the Solutions are already closed and unable to perform the operation.

--- a/solutions_test.go
+++ b/solutions_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ichiban/prolog/engine"
+	"github.com/axone-protocol/prolog/engine"
 
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
## Summary

This PR mark the decision of making this repository a hard fork of https://github.com/ichiban/prolog by renaming the go module to `github.com/axone-protocol/prolog`.

## Motivations

The existence of this repository was originally motivated by our needs in https://github.com/axone-protocol/axoned (e.g. to make this VM deterministic, increase execution control flow, control memory allocation, etc...), and the intention was at first, to propose to integrate these changes to the original repository.

As of today, we consider that these changes would have structural and behavioural impacts mismatching the approach conveyed by the original project, leading us to make this module independent, so that codebases depending on it are totally detached from `ichiban/prolog`.

## Impacts

Regarding codebases using this module, they must now directly import it under the new module name in their sources, and mention it under the `require` directives of their `go.mod`, removing the `replace` directive.

## Misc benefits

As we'll be detached from the original repository, we'll be able to rework the CI 💪.