### PR TITLE
🐛 Fix mishandling of **/ at the end of bracketed comment.

### DIFF
--- a/engine/lexer.go
+++ b/engine/lexer.go
@@ -296,6 +296,8 @@ func (l *Lexer) commentClose() (Token, error) {
 		return Token{}, err
 	case r == '/':
 		return l.layoutTextSequence(true)
+	case r == '*':
+		return l.commentClose()
 	default:
 		return l.commentText(true)
 	}

--- a/engine/lexer_test.go
+++ b/engine/lexer_test.go
@@ -40,6 +40,7 @@ func TestLexer_Token(t *testing.T) {
 		{input: `/ *`, token: Token{kind: tokenGraphic, val: `/`}},
 		{input: "/* comment *", err: io.EOF},
 		{input: `/🙈`, err: errMonkey},
+		{input: `/* **/foo`, token: Token{kind: tokenLetterDigit, val: "foo"}}, // https://github.com/ichiban/prolog/issues/326
 
 		{input: `改善`, token: Token{kind: tokenLetterDigit, val: `改善`}},
 		{input: `プロログ`, token: Token{kind: tokenLetterDigit, val: `プロログ`}},


### PR DESCRIPTION
Backport of https://github.com/ichiban/prolog/pull/333/commits/0ec73e279ff853c831f760cdf021ed12864709f0 fixing https://github.com/ichiban/prolog/issues/326.