### PR TITLE
Fix typo in atomPastEndOfStream definition

### DIFF
--- a/engine/atom.go
+++ b/engine/atom.go
@@ -136,7 +136,7 @@ var (
 	atomOutput                  = NewAtom("output")
 	atomPair                    = NewAtom("pair")
 	atomPast                    = NewAtom("past")
-	atomPastEndOfStream         = NewAtom("past_enf_of_stream")
+	atomPastEndOfStream         = NewAtom("past_end_of_stream")
 	atomPermissionError         = NewAtom("permission_error")
 	atomPhrase                  = NewAtom("phrase")
 	atomPi                      = NewAtom("pi")


### PR DESCRIPTION
Backport of https://github.com/ichiban/prolog/pull/337.