### PR TITLE
Docs/complete readme

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2021 Yutaka Ichibangase
+Copyright (c) 2024 Axone
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,176 +1,82 @@
-# ![prolog - the only reasonable scripting engine for Go](prolog.gif)
+[![axone github banner](https://raw.githubusercontent.com/axone-protocol/.github/main/profile/static/axone-banner.png)](https://axone.xyz)
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/ichiban/prolog.svg)](https://pkg.go.dev/github.com/ichiban/prolog)
-[![Actions Status](https://github.com/ichiban/prolog/actions/workflows/go.yml/badge.svg)](https://github.com/ichiban/prolog/actions)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ichiban/prolog)](https://goreportcard.com/report/github.com/ichiban/prolog)
-[![codecov](https://codecov.io/gh/ichiban/prolog/branch/main/graph/badge.svg?token=2FC3PZY7LN)](https://codecov.io/gh/ichiban/prolog)
-[![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go)
+<p align="center">
+  <a href="https://discord.gg/axone"><img src="https://img.shields.io/badge/Discord-7289DA?style=for-the-badge&logo=discord&logoColor=white" /></a> &nbsp;
+  <a href="https://www.linkedin.com/company/axone-protocol/"><img src="https://img.shields.io/badge/LinkedIn-0077B5?style=for-the-badge&logo=linkedin&logoColor=white" /></a> &nbsp;
+  <a href="https://twitter.com/axonexyz"><img src="https://img.shields.io/badge/Twitter-1DA1F2?style=for-the-badge&logo=twitter&logoColor=white" /></a> &nbsp;
+  <a href="https://blog.axone.xyz"><img src="https://img.shields.io/badge/Medium-12100E?style=for-the-badge&logo=medium&logoColor=white" /></a> &nbsp;
+  <a href="https://www.youtube.com/channel/UCiOfcTaUyv2Szv4OQIepIvg"><img src="https://img.shields.io/badge/YouTube-FF0000?style=for-the-badge&logo=youtube&logoColor=white" /></a>
+</p>
+
+# Axone Prolog Virtual Machine
+
+[![build](https://img.shields.io/github/actions/workflow/status/axone-protocol/prolog/go.yml?label=build&style=for-the-badge&logo=github)](https://github.com/axone-protocol/prolog/actions/workflows/go.yml)
+[![codecov](https://img.shields.io/codecov/c/github/axone-protocol/prolog?style=for-the-badge&token=O3FJO5QDCA&logo=codecov)](https://codecov.io/gh/axone-protocol/prolog)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-5272B4.svg?style=for-the-badge&logo=go)](https://pkg.go.dev/github.com/axone-protocol/prolog)
+[![Go Report Card](https://goreportcard.com/badge/github.com/axone-protocol/prolog?style=for-the-badge)](https://goreportcard.com/report/github.com/axone-protocol/prolog)
+[![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/axone-protocol/.github/blob/main/CODE_OF_CONDUCT.md)
+[![license](https://img.shields.io/github/license/axone-protocol/prolog.svg?label=License&style=for-the-badge)](https://opensource.org/license/mit)
 
 > [!IMPORTANT]
-> This repository is a *hard fork* of [ichiban/prolog](https://github.com/ichiban/prolog), customized to meet the specific requirements of the [Axone protocol](https://github.com/axone-protocol). It is maintained independently for our use case, and upstream updates may not be regularly integrated.
+> This repository is a _hard fork_ of [ichiban/prolog](https://github.com/ichiban/prolog), customized to meet the specific requirements of the [Axone protocol](https://github.com/axone-protocol). It is maintained independently for our use case, and upstream updates may not be regularly integrated.
 >
 > For the original, general-purpose Prolog implementation or to contribute to the broader community, please visit the [ichiban/prolog repository](https://github.com/ichiban/prolog).
 
 ## What is this?
 
-`ichiban/prolog` is an embeddable **ISO Prolog** interpreter in **Go**.
+`axone-protocol/prolog` is a Prolog virtual machine written in Go, designed to be embedded in blockchain environments.
+It serves as the core of the [Axone protocol](https://axone.xyz) for decentralized, logic-based smart contracts.
 
-- **Standards-compliant:**
-  - [ISO/IEC 13211-1:1995 Information technology — Programming languages — Prolog — Part 1: General core](https://www.iso.org/standard/21413.html)
-  - [A Prologue for Prolog](http://www.complang.tuwien.ac.at/ulrich/iso-prolog/prologue)
-  - [DCGs](https://www.complang.tuwien.ac.at/ulrich/iso-prolog/dcgs/dcgsdraft-2019-06-03.pdf)
-- **Easy to integrate:** `database/sql`-like Go API
-- **Highly customizable:**
-  - Sandboxing
-  - Custom predicates in Go
-  - Custom terms (data types) in Go
+This project is a fork of the [ichiban/prolog](https://github.com/ichiban/prolog) repository, striving to maintain
+ISO standard compliance where feasible while adapting to the unique constraints of blockchain execution.
 
-## Comparison with Other Libraries
+## Deviations from the ISO Standard
 
-|             | **prolog**             | otto            | go-lua          |
-| ----------- | ---------------------- | --------------- | --------------- |
-| Language    | ISO Prolog             | ECMA Script     | Lua             |
-| Paradigm    | 🎓 Logic               | Object-oriented | Object-oriented |
-| Go API      | 😻 `database/sql`-like | original        | original        |
-| Declarative | ✅                     | ❌              | ❌              |
-| Sandboxing  | ✅                     | ❌              | ✅              |
+The following customizations have been made to adapt the original `ichiban/prolog` implementation to the blockchain environment:
 
-## Getting started
-
-### Install latest version
-
-```console
-go get -u github.com/ichiban/prolog
-```
-
-### Usage
-
-#### Instantiate an interpreter
-
-```go
-p := prolog.New(os.Stdin, os.Stdout) // Or `prolog.New(nil, nil)` if you don't need user_input/user_output.
-```
-
-Or, if you want a sandbox interpreter without any built-in predicates:
-
-```go
-// See examples/sandboxing/main.go for details.
-p := new(prolog.Interpreter)
-```
-
-#### Load a Prolog program
-
-```go
-if err := p.Exec(`
-	human(socrates).       % This is a fact.
-	mortal(X) :- human(X). % This is a rule.
-`); err != nil {
-	panic(err)
-}
-```
-
-Similar to `database/sql`, you can use placeholder `?` to insert Go data as Prolog data.
-
-```go
-if err := p.Exec(`human(?).`, "socrates"); err != nil { // Same as p.Exec(`human("socrates").`)
-	panic(err)
-}
-```
-
-#### Run the Prolog program
-
-```go
-sols, err := p.Query(`mortal(?).`, "socrates") // Same as p.Query(`mortal("socrates").`)
-if err != nil {
-	panic(err)
-}
-defer sols.Close()
-
-// Iterates over solutions.
-for sols.Next() {
-	fmt.Printf("Yes.\n") // ==> Yes.
-}
-
-// Check if an error occurred while querying.
-if err := sols.Err(); err != nil {
-	panic(err)
-}
-```
-
-Or, if you want to query for the variable values for each solution:
-
-```go
-sols, err := p.Query(`mortal(Who).`)
-if err != nil {
-	panic(err)
-}
-defer sols.Close()
-
-// Iterates over solutions.
-for sols.Next() {
-	// Prepare a struct with fields which name corresponds with a variable in the query.
-	var s struct {
-		Who string
-	}
-	if err := sols.Scan(&s); err != nil {
-		panic(err)
-	}
-	fmt.Printf("Who = %s\n", s.Who) // ==> Who = socrates
-}
-
-// Check if an error occurred while querying.
-if err := sols.Err(); err != nil {
-	panic(err)
-}
-```
-
-## The Default Language
-
-`ichiban/prolog` adheres the ISO standard and comes with the ISO predicates as well as the Prologue for Prolog and DCG predicates.
-
-See [the Wiki](https://github.com/ichiban/prolog/wiki) for the directives and the built-in predicates.
-
-### Top Level
-
-`1pl` is an experimental top level command for testing the default language and its compliance to the ISO standard.
-
-You can install it with `go install`:
-
-```console
-go install github.com/ichiban/prolog/cmd/1pl@latest
-```
-
-Then, you can enter the top level with `1pl`:
-
-```console
-$(go env GOPATH)/bin/1pl [<file>...]
-```
-
-## Extensions
-
-- **[predicates](https://github.com/guregu/predicates):** Native predicates for ichiban/prolog.
-- **[kagomelog](https://github.com/ichiban/kagomelog):** a Japanese morphological analyzing predicate.
+- Capped variable allocation to limit the number of variables.
+- Replaced maps with ordered maps to ensure deterministic execution.
+- Implemented secure integer arithmetic for functors.
+- Integrated [cockroachdb/apd](https://github.com/cockroachdb/apd) for floating-point arithmetic.
+- Removed support for trigonometric functions (`sin`, `cos`, `tan`, `asin`, `acos`, `atan`).
+- Introduced VM hooks for enhanced Prolog execution control.
+- Added support for the `Dict` term.
 
 ## License
 
 Distributed under the MIT license. See `LICENSE` for more information.
 
-## Contributing
+## Bug reports & feature requests
 
-See `ARCHITECTURE.md` for architecture details.
+If you notice anything not behaving how you expected, if you would like to make a suggestion or would like
+to request a new feature, please open a [**new issue**](https://github.com/axone-protocol/axoned/issues/new/choose). We appreciate any help
+you're willing to give!
 
-1. Fork it (https://github.com/ichiban/prolog/fork)
-2. Create your feature branch (git checkout -b feature/fooBar)
-3. Commit your changes (git commit -am 'Add some fooBar')
-4. Push to the branch (git push origin feature/fooBar)
-5. Create a new Pull Request
+> Don't hesitate to ask if you are having trouble setting up your project repository, creating your first branch or
+> configuring your development environment. Mentors and maintainers are here to help!
 
-## Acknowledgments
+## You want to get involved? 😍
 
-We would like to extend our thanks to the following individuals for their contributions to this project:
+So you want to contribute? Great! ❤️ We appreciate any help you're willing to give. Don't hesitate to open issues and/or
+submit pull requests.
 
-- [guregu](https://github.com/guregu) for contributing code and ideas
-- [Markus Triska](https://github.com/triska) for his deep knowledge and insights on modern Prolog, as evidenced by his insightful comments on issues
-- [Prof. Ulrich Neumerkel](https://github.com/UWN) for valuable guidance, his [works on ISO standards](http://www.complang.tuwien.ac.at/ulrich/iso-prolog/), [the Prologue for Prolog](http://www.complang.tuwien.ac.at/ulrich/iso-prolog/prologue), and DCGs.
+We believe that collaboration is key to the success of the Axone project. Join our Community discussions on the [Community space](https://github.com/orgs/axone-protocol/discussions) to:
 
-We are grateful for the support and contributions of everyone involved in this project. Arigatou gozaimasu!
+- Engage in conversations with peers and experts.
+- Share your insights and experiences with Axone.
+- Learn from others and expand your knowledge of the protocol.
+
+The Community space serves as a hub for discussions, questions, and knowledge-sharing related to Axone.
+We encourage you to actively participate and contribute to the growth of our community.
+
+Please check out Axone health files:
+
+- [Contributing](https://github.com/axone-protocol/.github/blob/main/CONTRIBUTING.md)
+- [Code of conduct](https://github.com/axone-protocol/.github/blob/main/CODE_OF_CONDUCT.md)
+
+## Acknowledgements
+
+We would like to thank the following projects for their inspiration and for providing the foundation for this project:
+
+- [ichiban](https://github.com/ichiban) for the original Prolog implementation.


### PR DESCRIPTION
Update `LICENSE` and `README.md` to reflect the transition from `ichiban/prolog` to `axone-protocol/prolog` as a hard fork, preserving the original author's copyright and licensing terms.