### PR TITLE
Security/forbid halt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following customizations have been made to adapt the original `ichiban/prolo
 - Removed support for trigonometric functions (`sin`, `cos`, `tan`, `asin`, `acos`, `atan`).
 - Introduced VM hooks for enhanced Prolog execution control.
 - Added support for the `Dict` term.
+- `halt/0` and `halt/1` are forbidden and will throw an error.
 
 ## License
 

--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -1960,7 +1960,9 @@ func PeekChar(vm *VM, streamOrAlias, char Term, k Cont, env *Env) *Promise {
 	}
 }
 
-var osExit = os.Exit
+var osExit = func(_ int) {
+	panic("halt/1 is not allowed")
+}
 
 // Halt exits the process with exit code of n.
 func Halt(_ *VM, n Term, k Cont, env *Env) *Promise {

--- a/engine/promise.go
+++ b/engine/promise.go
@@ -162,10 +162,12 @@ func ensurePromise(p **Promise) {
 
 func panicError(r interface{}) error {
 	switch r := r.(type) {
+	case Exception:
+		return r
 	case error:
-		return PanicError{r}
+		return Exception{term: atomError.Apply(NewAtom("panic_error").Apply(NewAtom(r.Error())))}
 	default:
-		return PanicError{fmt.Errorf("%v", r)}
+		return Exception{term: atomError.Apply(NewAtom("panic_error").Apply(NewAtom(fmt.Sprintf("%v", r))))}
 	}
 }
 


### PR DESCRIPTION
This PR enforces the disallowance of the `halt/1` predicate, which now throws the error `error(panic_error('halt/1 is not allowed'))` when invoked.

Previously, this predicate was unregistered in the axone blockchain’s `logic` module (https://github.com/axone-protocol/axoned/commit/293da10e8c24ec1712c8c700330beb9e213c3819). However, as the VM is now designed to be safely embedded in a blockchain, this predicate must be explicitly controlled at the VM level to ensure robust security.