### PR TITLE
Feat/get dict 4

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./... -race -coverprofile=coverage.txt -covermode=atomic
+      run: go test -v -race -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt ./...
 
     - name: Codecov
       uses: codecov/codecov-action@v4

--- a/engine/dict_test.go
+++ b/engine/dict_test.go
@@ -168,8 +168,7 @@ func TestDictAll(t *testing.T) {
 			wantPairs: []orderedmap.Pair[Atom, Term]{
 				{Key: NewAtom("x"), Value: Integer(1)},
 				{Key: NewAtom("y"), Value: Integer(2)},
-				{Key: NewAtom("z"), Value: makeDict(NewAtom("nested"), NewAtom("foo"), NewAtom("bar")),
-				},
+				{Key: NewAtom("z"), Value: makeDict(NewAtom("nested"), NewAtom("foo"), NewAtom("bar"))},
 			},
 		},
 	}
@@ -455,6 +454,18 @@ func TestOp3(t *testing.T) {
 			function:  NewAtom("get").Apply(Integer(1)),
 			wantError: "error(domain_error(dict_key,1),root)",
 		},
+		{
+			name:       "get existing key with default value",
+			dict:       makeDict(NewAtom("point"), NewAtom("x"), Integer(1), NewAtom("y"), Integer(2)),
+			function:   NewAtom("get").Apply(NewAtom("x"), Integer(99)),
+			wantResult: Integer(1),
+		},
+		{
+			name:       "get non-existing key with default value",
+			dict:       makeDict(NewAtom("point"), NewAtom("x"), Integer(1), NewAtom("y"), Integer(2)),
+			function:   NewAtom("get").Apply(NewAtom("z"), Integer(99)),
+			wantResult: Integer(99),
+		},
 		// Put
 		{
 			name:       "put new key(value) pair",
@@ -540,6 +551,12 @@ func TestOp3(t *testing.T) {
 			dict:      makeDict(NewAtom("point"), NewAtom("x"), Integer(1), NewAtom("y"), Integer(2)),
 			function:  NewAtom("foo").Apply(NewAtom("bar")),
 			wantError: "error(existence_error(procedure,foo(bar)),root)",
+		},
+		{
+			name:      "invalid function arity for predefined function",
+			dict:      makeDict(NewAtom("point"), NewAtom("x"), Integer(1), NewAtom("y"), Integer(2)),
+			function:  NewAtom("get").Apply(NewAtom("x"), NewAtom("y"), NewAtom("z")),
+			wantError: "error(existence_error(procedure,get(x,y,z)),root)",
 		},
 	}
 

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -1132,6 +1132,18 @@ func TestDict(t *testing.T) {
 			wantResult: []result{},
 		},
 		{
+			query: `A = point{x:1,y:2}.get(foo, 42).`,
+			wantResult: []result{{solutions: map[string]TermString{
+				"A": "42",
+			}}},
+		},
+		{
+			query: `A = point{x:1}.get(x, 42).`,
+			wantResult: []result{{solutions: map[string]TermString{
+				"A": "1",
+			}}},
+		},
+		{
 			query: "S = segment{to:point{y:20, x:10}, from:point{y:2, x:1}}.get(to/x).",
 			wantResult: []result{{solutions: map[string]TermString{
 				"S": "10",
@@ -1148,6 +1160,12 @@ func TestDict(t *testing.T) {
 			}}},
 		},
 		{
+			query: `S = segment{from:point{a:1}}.get(from/z, 0).`,
+			wantResult: []result{{solutions: map[string]TermString{
+				"S": "0",
+			}}},
+		},
+		{
 			query: "S = point{x:5}.get(/(x,y,z)).",
 			wantResult: []result{{
 				err: fmt.Errorf("error(domain_error(dict_key,/(x,y,z)),. /3)"),
@@ -1160,7 +1178,19 @@ func TestDict(t *testing.T) {
 			}},
 		},
 		{
+			query: `S = point{}.get(foo, default).`,
+			wantResult: []result{{solutions: map[string]TermString{
+				"S": "default",
+			}}},
+		},
+		{
 			query: "S = X.get(x).",
+			wantResult: []result{{
+				err: fmt.Errorf("error(instantiation_error,. /3)"),
+			}},
+		},
+		{
+			query: `S = point{}.get(foo, D).`,
 			wantResult: []result{{
 				err: fmt.Errorf("error(instantiation_error,. /3)"),
 			}},


### PR DESCRIPTION
This PR introduces the `get_dict/4` _builtin_, following the semantics defined in [SWI-Prolog’s predefined dict predicates](https://www.swi-prolog.org/pldoc/man?section=ext-dicts-predefined).

The new builtin allows querying a dictionary with a default value when the key is not present.

```prolog
?- get_dict(x, point{x:1}, V, 42).
V = 1.

?- get_dict(x, point{}, V, 42).
V = 42.
```