### PR TITLE
Feat/add del dict 4

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -68,7 +68,9 @@ func New(in io.Reader, out io.Writer) *Interpreter {
 	// Dicts operator
 	i.Register3(engine.NewAtom("."), engine.Op3)
 	i.Register3(engine.NewAtom("get_dict"), engine.GetDict3)
+	i.Register4(engine.NewAtom("get_dict"), engine.GetDict4)
 	i.Register3(engine.NewAtom("put_dict"), engine.PutDict3)
+	i.Register4(engine.NewAtom("del_dict"), engine.DelDict4)
 
 	// Arithmetic evaluation
 	i.Register2(engine.NewAtom("is"), engine.Is)


### PR DESCRIPTION
Introduces the `del_dict/4`	 builtin, aligning with the behavior documented in [SWI-Prolog’s dict predicates](https://www.swi-prolog.org/pldoc/man?section=ext-dict-predicates).

The new predicate removes a key–value pair from a dictionary, unifying the removed value and the resulting dictionary with the corresponding arguments. It fails when the key is absent and raises appropriate instantiation, type, or domain errors for invalid inputs.

```prolog
?- del_dict(x, point{x:1, y:2}, V, D).
V = 1,
D = point{y:2}.

?- del_dict(z, point{x:1, y:2}, V, D).
false.
```