### PR TITLE
build(project): enable golanci-lint errcheck

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,5 +3,6 @@ version: "2"
 linters:
   default: none
   enable:
+    - errcheck
     - ineffassign
     - unused

--- a/examples/sandboxing/main.go
+++ b/examples/sandboxing/main.go
@@ -39,7 +39,11 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer sols.Close()
+	defer func() {
+		if err := sols.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	for sols.Next() {
 		var s struct {

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -1346,7 +1346,9 @@ func TestDict(t *testing.T) {
 			}
 			assert.NoError(t, err)
 			assert.NotNil(t, sols)
-			defer sols.Close()
+			defer func() {
+				assert.NoError(t, sols.Close())
+			}()
 
 			for _, tr := range tt.wantResult {
 				ok := sols.Next()


### PR DESCRIPTION
Enable [errcheck](https://golangci-lint.run/docs/linters/configuration/#errcheck) in the Go _lint_ baseline.