### PR TITLE
Ci/golangci lint more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,4 +6,5 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - staticcheck
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,5 +7,6 @@ linters:
     - govet
     - ineffassign
     - staticcheck
+    - unconvert
     - unused
     - wastedassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,4 @@ linters:
     - ineffassign
     - staticcheck
     - unused
+    - wastedassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,7 @@ linters:
     - errcheck
     - govet
     - ineffassign
+    - nilerr
     - staticcheck
     - unconvert
     - unused

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,5 +4,6 @@ linters:
   default: none
   enable:
     - errcheck
+    - govet
     - ineffassign
     - unused

--- a/cmd/1pl/main.go
+++ b/cmd/1pl/main.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"strings"
 
-	"golang.org/x/crypto/ssh/terminal"
+	terminal "golang.org/x/term"
 
 	"github.com/axone-protocol/prolog/v3"
 	"github.com/axone-protocol/prolog/v3/engine"
@@ -89,8 +89,6 @@ Type Ctrl-C or 'halt.' to exit.
 	keys := bufio.NewReader(os.Stdin)
 	for {
 		switch err := handleLine(ctx, &buf, i, t, keys); err {
-		case nil:
-			break
 		case io.EOF:
 			return
 		default:

--- a/engine/builtin.go
+++ b/engine/builtin.go
@@ -2849,7 +2849,7 @@ func expand(vm *VM, term Term, env *Env) (Term, error) {
 
 	t, err := expandDCG(term, env)
 	if err != nil {
-		return term, nil
+		return term, nil //nolint:nilerr // Failed DCG expansion leaves the input unchanged.
 	}
 	return t, err
 }

--- a/engine/builtin_test.go
+++ b/engine/builtin_test.go
@@ -3760,7 +3760,7 @@ func TestOpen(t *testing.T) {
 				// Should be able to read
 				assert.NoError(t, s.initRead())
 				b := make([]byte, 7)
-				n, err := s.source.(io.Reader).Read(b)
+				n, err := s.source.Read(b)
 				assert.NoError(t, err)
 				assert.Equal(t, 7, n)
 				assert.Equal(t, "initial", string(b))

--- a/engine/compound.go
+++ b/engine/compound.go
@@ -296,7 +296,7 @@ type errWriter struct {
 
 func (ew *errWriter) Write(p []byte) (int, error) {
 	if ew.err != nil {
-		return 0, nil
+		return 0, nil //nolint:nilerr // errWriter retains the first error for the caller.
 	}
 	var n int
 	n, ew.err = ew.w.Write(p)

--- a/engine/number.go
+++ b/engine/number.go
@@ -667,7 +667,7 @@ func bitwiseRightShift(n, s Number) (Number, error) {
 	case Integer:
 		switch s := s.(type) {
 		case Integer:
-			return Integer(n >> s), nil
+			return n >> s, nil
 		default:
 			return nil, typeError(validTypeInteger, s, nil)
 		}
@@ -682,7 +682,7 @@ func bitwiseLeftShift(n, s Number) (Number, error) {
 	case Integer:
 		switch s := s.(type) {
 		case Integer:
-			return Integer(n << s), nil
+			return n << s, nil
 		default:
 			return nil, typeError(validTypeInteger, s, nil)
 		}

--- a/engine/parser.go
+++ b/engine/parser.go
@@ -816,8 +816,6 @@ func (p *Parser) dict() (Term, error) {
 	tag, err = p.atom()
 	switch err {
 	case nil:
-	default:
-		return nil, err
 	case errExpectation:
 		t, err := p.next()
 		if err != nil {
@@ -830,6 +828,8 @@ func (p *Parser) dict() (Term, error) {
 		default:
 			return nil, errExpectation
 		}
+	default:
+		return nil, err
 	}
 
 	args = append(args, tag)

--- a/engine/parser.go
+++ b/engine/parser.go
@@ -388,7 +388,7 @@ func (p *Parser) term(maxPriority Integer) (Term, error) {
 		}
 	}
 
-	return lhs, nil
+	return lhs, nil //nolint:nilerr // An infix parse error ends the operator chain.
 }
 
 func (p *Parser) prefix(maxPriority Integer) (operator, error) {

--- a/engine/stream_test.go
+++ b/engine/stream_test.go
@@ -809,7 +809,7 @@ func TestStream_ReadWrite(t *testing.T) {
 
 func (r nonAbruptReader) Read(b []byte) (int, error) {
 	n, err := r.Reader.Read(b)
-	if err == nil && r.Reader.Len() == 0 {
+	if err == nil && r.Len() == 0 {
 		err = io.EOF
 	}
 	return n, err

--- a/engine/variable.go
+++ b/engine/variable.go
@@ -54,7 +54,7 @@ func (v Variable) WriteTerm(w io.Writer, opts *WriteOptions, env *Env) error {
 	if a, ok := opts.variableNames[v]; ok {
 		_ = a.WriteTerm(&ew, opts.withQuoted(false).withLeft(operator{}).withRight(operator{}), env)
 	} else {
-		_, _ = ew.Write([]byte(fmt.Sprintf("_%d", v)))
+		_, _ = fmt.Fprintf(&ew, "_%d", v)
 	}
 	if letterDigit(opts.right.name) {
 		_, _ = ew.Write([]byte(" "))

--- a/engine/vm.go
+++ b/engine/vm.go
@@ -299,7 +299,7 @@ func (vm *VM) exec(pc bytecode, vars []Variable, cont Cont, args []Term, astack 
 		case OpPop:
 			args, astack = astack[len(astack)-1], astack[:len(astack)-1]
 		case OpEnter:
-			break
+			// Enter marks the start of a clause; no register changes are needed.
 		case OpCall:
 			pi := operand.(procedureIndicator)
 			return vm.Arrive(pi.name, args, func(env *Env) *Promise {

--- a/engine/vm_test.go
+++ b/engine/vm_test.go
@@ -349,8 +349,8 @@ func TestVM_ResetEnv(t *testing.T) {
 
 		assert.Equal(t, uint64(1), varCounter.count) // 1 because NewVariable() is called in ResetEnv()
 		assert.Equal(t, "root", rootContext.String())
-		assert.Equal(t, newEnvKey(varContext), rootEnv.binding.key)
-		assert.Equal(t, NewAtom("root"), rootEnv.binding.value)
+		assert.Equal(t, newEnvKey(varContext), rootEnv.key)
+		assert.Equal(t, NewAtom("root"), rootEnv.value)
 		assert.Equal(t, uint64(20), maxVariables)
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/cockroachdb/apd/v3 v3.2.3
 	github.com/stretchr/testify v1.11.1
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	golang.org/x/crypto v0.54.0
+	golang.org/x/term v0.45.0
 )
 
 require (
@@ -19,7 +19,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	golang.org/x/sys v0.47.0 // indirect
-	golang.org/x/term v0.45.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
 github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
-golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
-golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=

--- a/solutions.go
+++ b/solutions.go
@@ -52,7 +52,7 @@ func (s *Solutions) Next() bool {
 // Scan copies the variable values of the current solution into the specified struct/map.
 func (s *Solutions) Scan(dest interface{}) error {
 	o := reflect.ValueOf(dest)
-	for o.Kind() == reflect.Ptr {
+	for o.Kind() == reflect.Pointer {
 		o = o.Elem()
 	}
 	switch o.Kind() {


### PR DESCRIPTION
Enable golangci-lint `govet`, `staticcheck`, `wastedassign`, `unconvert` and `nilerr` linters.